### PR TITLE
lixPackageSets.lix_2_92: default to nixpkgs from registry in default-flake patch

### DIFF
--- a/pkgs/tools/package-management/lix/2.92-patches/0001-feat-add-default-flake.patch
+++ b/pkgs/tools/package-management/lix/2.92-patches/0001-feat-add-default-flake.patch
@@ -116,7 +116,7 @@ index 423ea33d8..1c95e422c 100644
 +
 +struct InstallablesSettings : Config
 +{
-+    Setting<std::string> defaultFlake{this, "", "default-flake",
++    Setting<std::string> defaultFlake{this, "nixpkgs", "default-flake",
 +        "The default flake URL when using the command line interface"};
 +
 +    std::string getDefaultFlake(std::string_view url);

--- a/pkgs/tools/package-management/lix/default.nix
+++ b/pkgs/tools/package-management/lix/default.nix
@@ -170,11 +170,11 @@ lib.makeExtensible (self: {
       };
 
       patches = [
-          2.92-patches/0001-feat-add-default-flake.patch
-          2.92-patches/0002-feat-add-builtins.bitShift.patch
-          2.92-patches/0003-feat-add-reject-flake-config-setting-to-reject-all-n.patch
-          2.92-patches/0004-fix-version-string.patch
-          2.92-patches/0005-fix-silence-settings-warnings.patch
+        2.92-patches/0001-feat-add-default-flake.patch
+        2.92-patches/0002-feat-add-builtins.bitShift.patch
+        2.92-patches/0003-feat-add-reject-flake-config-setting-to-reject-all-n.patch
+        2.92-patches/0004-fix-version-string.patch
+        2.92-patches/0005-fix-silence-settings-warnings.patch
       ];
     };
 


### PR DESCRIPTION
Tested locally, and have been daily-driving a similar patch before Lix 2.92.
